### PR TITLE
Generate Unique Request Id Interceptor Layer to Trace Requests and Responses

### DIFF
--- a/src/main/kotlin/com/atauchi/transformerFileService/adapters/controllers/HealthCheckController.kt
+++ b/src/main/kotlin/com/atauchi/transformerFileService/adapters/controllers/HealthCheckController.kt
@@ -1,0 +1,14 @@
+package com.atauchi.transformerFileService.adapters.controllers
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthCheckController {
+    @GetMapping("/healthcheck")
+    fun getHealthCheck(): ResponseEntity<String> {
+        return ResponseEntity<String>("{message: OK}", HttpStatus.OK)
+    }
+}

--- a/src/main/kotlin/com/atauchi/transformerFileService/config/WebConfig.kt
+++ b/src/main/kotlin/com/atauchi/transformerFileService/config/WebConfig.kt
@@ -1,0 +1,17 @@
+package com.atauchi.transformerFileService.config
+
+import com.atauchi.transformerFileService.infra.interceptors.RequestInterceptor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    @Autowired
+    private lateinit var requestInterceptor: RequestInterceptor
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(requestInterceptor)
+    }
+}

--- a/src/main/kotlin/com/atauchi/transformerFileService/infra/interceptors/RequestInterceptor.kt
+++ b/src/main/kotlin/com/atauchi/transformerFileService/infra/interceptors/RequestInterceptor.kt
@@ -1,0 +1,56 @@
+package com.atauchi.transformerFileService.infra.interceptors
+
+import com.atauchi.transformerFileService.utilities.constants.UuidGenerator
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import java.lang.Exception
+
+@Component
+class RequestInterceptor : HandlerInterceptor {
+    private val logger: Logger = LoggerFactory.getLogger(RequestInterceptor::class.java)
+
+    @Autowired
+    private lateinit var uuidGenerator: UuidGenerator
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        val requestId: String = uuidGenerator.generate()
+        MDC.put("requestId", requestId)
+        logIncomingRequestDetails(request, requestId)
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?,
+    ) {
+        val requestId: String = MDC.get("requestId") ?: "N/A"
+        logCompletedRequestDetails(response, requestId)
+        MDC.remove("requestId")
+    }
+
+    private fun logIncomingRequestDetails(
+        request: HttpServletRequest,
+        requestId: String,
+    ) {
+        logger.info("Incoming request requestId=$requestId method=${request.method} uri=${request.requestURI}")
+    }
+
+    private fun logCompletedRequestDetails(
+        response: HttpServletResponse,
+        requestId: String,
+    ) {
+        logger.info("Completed request requestId=$requestId status=${response.status}")
+    }
+}

--- a/src/main/kotlin/com/atauchi/transformerFileService/utilities/constants/HealthCheckConstants.kt
+++ b/src/main/kotlin/com/atauchi/transformerFileService/utilities/constants/HealthCheckConstants.kt
@@ -1,0 +1,6 @@
+package com.atauchi.transformerFileService.utilities.constants
+
+object HealthCheckConstants {
+    const val BASE_URL: String = ""
+    const val GET_HEALTH_CHECK_URL = "/healthcheck"
+}

--- a/src/main/kotlin/com/atauchi/transformerFileService/utilities/constants/UuidGenerator.kt
+++ b/src/main/kotlin/com/atauchi/transformerFileService/utilities/constants/UuidGenerator.kt
@@ -1,0 +1,11 @@
+package com.atauchi.transformerFileService.utilities.constants
+
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class UuidGenerator {
+    fun generate(): String {
+        return UUID.randomUUID().toString()
+    }
+}

--- a/src/test/kotlin/com/atauchi/transformerFileService/adapters/controllers/HealthCheckControllerTests.kt
+++ b/src/test/kotlin/com/atauchi/transformerFileService/adapters/controllers/HealthCheckControllerTests.kt
@@ -1,10 +1,12 @@
 package com.atauchi.transformerFileService.adapters.controllers
 
 import com.atauchi.transformerFileService.utilities.constants.HealthCheckConstants
+import com.atauchi.transformerFileService.utilities.constants.UuidGenerator
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -12,6 +14,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest
 class HealthCheckControllerTests {
+    @MockBean
+    private lateinit var uuidGenerator: UuidGenerator
+
     @Autowired
     private lateinit var mockMvc: MockMvc
 

--- a/src/test/kotlin/com/atauchi/transformerFileService/adapters/controllers/HealthCheckControllerTests.kt
+++ b/src/test/kotlin/com/atauchi/transformerFileService/adapters/controllers/HealthCheckControllerTests.kt
@@ -1,0 +1,33 @@
+package com.atauchi.transformerFileService.adapters.controllers
+
+import com.atauchi.transformerFileService.utilities.constants.HealthCheckConstants
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest
+class HealthCheckControllerTests {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    private lateinit var healthCheckUrl: String
+
+    @BeforeEach
+    fun setUp() {
+        healthCheckUrl = HealthCheckConstants.BASE_URL + HealthCheckConstants.GET_HEALTH_CHECK_URL
+    }
+
+    @Test
+    fun `should check health of the system is ok`() {
+        // When
+        val response: ResultActions = mockMvc.perform(get(healthCheckUrl))
+
+        // Then
+        response.andExpect(status().isOk)
+    }
+}

--- a/src/test/kotlin/com/atauchi/transformerFileService/infra/interceptors/RequestInterceptorTests.kt
+++ b/src/test/kotlin/com/atauchi/transformerFileService/infra/interceptors/RequestInterceptorTests.kt
@@ -1,0 +1,72 @@
+package com.atauchi.transformerFileService.infra.interceptors
+
+import com.atauchi.transformerFileService.utilities.constants.HealthCheckConstants
+import com.atauchi.transformerFileService.utilities.constants.UuidGenerator
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(MockitoExtension::class)
+@ExtendWith(OutputCaptureExtension::class)
+@AutoConfigureMockMvc
+class RequestInterceptorTests {
+    @MockBean
+    lateinit var uuidGenerator: UuidGenerator
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    private lateinit var healthCheckUrl: String
+
+    @BeforeEach
+    fun setUp() {
+        healthCheckUrl = HealthCheckConstants.BASE_URL + HealthCheckConstants.GET_HEALTH_CHECK_URL
+    }
+
+    @Test
+    fun `should generate log info with a request id in request and response`(output: CapturedOutput) {
+        // Given it is generate a request di
+        val mockUuid: String = "0001"
+        `when`(uuidGenerator.generate()).thenReturn(mockUuid)
+
+        // When
+        val response: ResultActions = mockMvc.perform(get(healthCheckUrl))
+
+        // Then
+        val expectedRequestLog = "Incoming request requestId=$mockUuid method=GET uri=/healthcheck"
+        val expectedResponseLog = "Completed request requestId=$mockUuid status=200"
+        response.andExpect(status().isOk)
+        assertTrue(output.out.contains(expectedRequestLog))
+        assertTrue(output.out.contains(expectedResponseLog))
+    }
+
+    @Test
+    fun `should check MDC requestId value in response`() {
+        // Given it is generate a request di
+        val mockUuid: String = "0001"
+        `when`(uuidGenerator.generate()).thenReturn(mockUuid)
+
+        // When
+        val response: ResultActions = mockMvc.perform(get(healthCheckUrl))
+
+        // Then after response is removed requestId from MDC
+        response.andExpect(status().isOk)
+        assertNull(MDC.get("requestId"))
+    }
+}

--- a/src/test/kotlin/com/atauchi/transformerFileService/utilities/constants/HealthCheckConstantsTests.kt
+++ b/src/test/kotlin/com/atauchi/transformerFileService/utilities/constants/HealthCheckConstantsTests.kt
@@ -1,0 +1,12 @@
+package com.atauchi.transformerFileService.utilities.constants
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class HealthCheckConstantsTests {
+    @Test
+    fun `should verify url api for health check system`() {
+        assertThat(HealthCheckConstants.BASE_URL).isEqualTo("")
+        assertThat(HealthCheckConstants.GET_HEALTH_CHECK_URL).isEqualTo("/healthcheck")
+    }
+}


### PR DESCRIPTION
# Description

In this Pr, it was implemented a feature to generate request id in order to use in trace operations for request and responses.

- The requestId will help to trace flow from request until response in our REST API
- The requestId is generate using the UUID from java
- The requetsId will store in MDC from "org.slf4j.MDC"
- After finished the request i.e. the response, the requestId will be deleted from MDC
- Additionally from the requestId, also in request is put the method and the endpoint called, as well as in the response, it is put the status code of the response

# Tests
- automatic tests were implemented
- for manual test, run the app and then make a request to the endpoint /healthcheck, and in logs see the messages from incoming request and completed request both with a requestId